### PR TITLE
Include CircuitOpen's cause on the runner who causes opening the circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.3.1]
+### Changed
+- `CircuitOpen` exceptions from tasks which trigger opening the circuit will now include the `__cause__`.
+
 ## [0.3.0]
 ### Added
 - Add functionality to wait before executing a retry. There is a new `backoff` option in `RetryPolicy` which allows to define the wait time. (Thanks to @fcurella for this contribution!)

--- a/failsafe/__init__.py
+++ b/failsafe/__init__.py
@@ -7,4 +7,4 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/failsafe/failsafe.py
+++ b/failsafe/failsafe.py
@@ -72,7 +72,10 @@ class Failsafe:
         while retry:
             if not self.circuit_breaker.allows_execution():
                 logger.debug("Circuit open, stopping execution")
-                raise CircuitOpen()
+                if recent_exception is None:
+                    raise CircuitOpen()
+                else:
+                    raise CircuitOpen() from recent_exception
             try:
                 context.attempts += 1
                 result = await callable()


### PR DESCRIPTION
When a task is executing `Failsafe.run` and records a failure in the circuit_breaker which opens the circuit and then retries, then the CircuitOpen exception raised does not contain the original root cause of the issue.

This means that the original exception which causes to open a circuit is hidden/silenced.

In this pull request I propose to include the last `recent_exception` (only when it exists -> if you call Failsafe.run with the circuit open there is no recent_exception to include as a cause of an exception).


Note: I didn't use `pytest.raises` in the tests because that returns an `ExceptionInfo` exception which does not contain the `__cause__` object, which I need to assert the CircuitOpen exception is correct.