### PR TITLE
Added half-open state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.4.0]
+### Added
+- Added half-open state, thus implementing Fowler's Circuit model (https://martinfowler.com/bliki/CircuitBreaker.html) 
+
 ## [0.3.1]
 ### Changed
 - `CircuitOpen` exceptions from tasks which trigger opening the circuit will now include the `__cause__`.

--- a/failsafe/__init__.py
+++ b/failsafe/__init__.py
@@ -7,4 +7,4 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'

--- a/failsafe/circuit_breaker.py
+++ b/failsafe/circuit_breaker.py
@@ -67,6 +67,13 @@ class CircuitBreaker:
         self.state = _OpenState(self)
         logger.debug("Opened")
 
+    def half_open(self):
+        """
+        Sets the state of the CircuitBreaker to half open
+        """
+        self.state = _HalfOpenState(self)
+        logger.debug("Half opened")
+
     def close(self):
         """
         Sets the state of the CircuitBreaker to closed
@@ -119,7 +126,7 @@ class _OpenState:
 
     def allows_execution(self):
         if time.monotonic() > self.opened_at + self.circuit_breaker.reset_timeout_seconds:
-            self.circuit_breaker.close()
+            self.circuit_breaker.half_open()
             return True
 
         return False
@@ -132,6 +139,27 @@ class _OpenState:
 
     def get_name(self):
         return 'open'
+
+
+class _HalfOpenState:
+    """
+    A status class representing the half open state of a CircuitBreaker
+    """
+
+    def __init__(self, circuit_breaker):
+        self.circuit_breaker = circuit_breaker
+
+    def allows_execution(self):
+        return True
+
+    def record_success(self):
+        self.circuit_breaker.close()
+
+    def record_failure(self):
+        self.circuit_breaker.open()
+
+    def get_name(self):
+        return 'half-open'
 
 
 class AlwaysClosedCircuitBreaker(CircuitBreaker):

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -104,3 +104,20 @@ class TestCircuitBreaker:
 
         assert circuit_breaker.allows_execution() is False
         assert circuit_breaker.current_state == 'open'
+
+    def test_half_open_state_ratio(self):
+        ratio = 0.2
+        total_executions = 1000
+
+        circuit_breaker = CircuitBreaker(half_open_ratio=ratio)
+        circuit_breaker.half_open()
+
+        results = []
+        for i in range(0, total_executions):
+            results.append(circuit_breaker.allows_execution())
+            assert circuit_breaker.current_state == 'half-open'
+
+        allowed_executions = list(filter(lambda x: x is True, results))
+
+        assert len(results) == total_executions
+        assert len(allowed_executions) == total_executions * ratio

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -58,7 +58,7 @@ class TestCircuitBreaker:
         assert circuit_breaker.current_state == 'closed'
 
     @patch('time.monotonic')
-    def test_circuit_closes_again_after_timeout(self, monotonic_mock):
+    def test_circuit_half_opens_and_closes_after_timeout(self, monotonic_mock):
         circuit_breaker = CircuitBreaker(maximum_failures=1, reset_timeout_seconds=20)
 
         assert circuit_breaker.allows_execution() is True
@@ -74,4 +74,33 @@ class TestCircuitBreaker:
         monotonic_mock.return_value = 130
 
         assert circuit_breaker.allows_execution() is True
+        assert circuit_breaker.current_state == 'half-open'
+
+        circuit_breaker.record_success()
+
+        assert circuit_breaker.allows_execution() is True
         assert circuit_breaker.current_state == 'closed'
+
+    @patch('time.monotonic')
+    def test_circuit_stays_open_upon_failure_after_half_opening(self, monotonic_mock):
+        circuit_breaker = CircuitBreaker(maximum_failures=1, reset_timeout_seconds=20)
+
+        assert circuit_breaker.allows_execution() is True
+        assert circuit_breaker.current_state == 'closed'
+
+        monotonic_mock.return_value = 100
+
+        circuit_breaker.record_failure()
+
+        assert circuit_breaker.allows_execution() is False
+        assert circuit_breaker.current_state == 'open'
+
+        monotonic_mock.return_value = 130
+
+        assert circuit_breaker.allows_execution() is True
+        assert circuit_breaker.current_state == 'half-open'
+
+        circuit_breaker.record_failure()
+
+        assert circuit_breaker.allows_execution() is False
+        assert circuit_breaker.current_state == 'open'


### PR DESCRIPTION
Added the half-open state according to the model described in https://martinfowler.com/bliki/CircuitBreaker.html. 

Essentially, before closing after being open, the circuit stays half open, allowing one request to go through. If the request is successful, the circuit closes, otherwise stays open. This way we avoid bursts of `maximum_failures` errors each time the circuit-open timeout is over but the service is still in no condition of serving requests.