### PR TITLE
Issue35 add all arguments to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.5.0]
+### Changed
+- Made the ``Failsafe.run()`` method accept all the ``*args`` and ``**kwargs`` from the original function.
+
 ## [0.4.0]
 ### Added
-- Added half-open state, thus implementing Fowler's Circuit model (https://martinfowler.com/bliki/CircuitBreaker.html) 
+- Added half-open state, thus implementing Fowler's Circuit model (https://martinfowler.com/bliki/CircuitBreaker.html)
 
 ## [0.3.1]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ async def make_get_request(url):
                 return await resp.json()
 
     try:
-        return await failsafe.run(lambda: _make_get_request(url))
+        return await failsafe.run(_make_get_request, url)
     except FailsafeError:
         raise RuntimeError("Error while getting data")
 

--- a/examples/failsafe_with_fallback.py
+++ b/examples/failsafe_with_fallback.py
@@ -35,7 +35,7 @@ class GitHubClient:
             return await self.failsafe_fallback.run(self._request, fallback_url)
 
     async def _request(self, url):
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession() as session:
             async with session.get(url) as resp:
                 if resp.status != 200:
                     raise Exception()

--- a/examples/failsafe_with_fallback.py
+++ b/examples/failsafe_with_fallback.py
@@ -28,11 +28,11 @@ class GitHubClient:
         try:
             # primary url intentionally wrong to simulate failure
             primary_url = 'https://wrong_url.github.com/orgs/{}/repos'.format(github_user)
-            return await self.failsafe.run(lambda: self._request(primary_url))
+            return await self.failsafe.run(self._request, primary_url)
         except FailsafeError:
             # primary endpoint is down, call secondary as a fallback:
             fallback_url = 'https://api.github.com/orgs/{}/repos'.format(github_user)
-            return await self.failsafe_fallback.run(lambda: self._request(fallback_url))
+            return await self.failsafe_fallback.run(self._request, fallback_url)
 
     async def _request(self, url):
         with aiohttp.ClientSession() as session:

--- a/examples/fallback_failsafe.py
+++ b/examples/fallback_failsafe.py
@@ -32,7 +32,7 @@ class GitHubClient:
     async def _request(self, endpoint, query_path):
         url = urljoin(endpoint, query_path)
 
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession() as session:
             async with session.get(url) as resp:
                 if resp.status != 200:
                     raise Exception()

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==0.22.5
+aiohttp==3.6.2
 pytest==2.9.2

--- a/examples/simple_failsafe.py
+++ b/examples/simple_failsafe.py
@@ -35,7 +35,7 @@ class GitHubClient:
         url = 'https://api.github.com/orgs/{}/repos'.format(github_user)
 
         try:
-            return await self.failsafe.run(lambda: self._request(url))
+            return await self.failsafe.run(self._request, url)
         except NotFoundError:
             raise UserNotFoundError("User {} was not found".format(github_user))
         except FailsafeError as e:

--- a/examples/simple_failsafe.py
+++ b/examples/simple_failsafe.py
@@ -42,7 +42,7 @@ class GitHubClient:
             raise GitHubClientError("Could not load repositories due to unknown error") from e
 
     async def _request(self, url):
-        with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession() as session:
             async with session.get(url) as resp:
                 if resp.status == 404:
                     raise NotFoundError()  # NotFoundError is abortable exception meaning that Failsafe will not retry

--- a/failsafe/__init__.py
+++ b/failsafe/__init__.py
@@ -7,4 +7,4 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'

--- a/failsafe/failsafe.py
+++ b/failsafe/failsafe.py
@@ -55,12 +55,15 @@ class Failsafe:
             circuit_breaker = AlwaysClosedCircuitBreaker()
         self.circuit_breaker = circuit_breaker
 
-    async def run(self, callable):
+    async def run(self, callable, *args, **kwargs):
         """
         Calls the callable method according to the retry_policy and the circuit_breaker
         specified in the instance.
 
         :param callable: method to call.
+        :param *args:    The original positional arguments of the method to call (<callable>).
+        :param **kwargs: The original keyword arguments of the method to call (<callable>).
+
         :raises: RetriesExhausted when the retry policy attempts has been reached.
         :raises: CircuitOpen when the circuit_breaker policy has reached the
             maximum allowed number of failures
@@ -78,7 +81,7 @@ class Failsafe:
                     raise CircuitOpen() from recent_exception
             try:
                 context.attempts += 1
-                result = await callable()
+                result = await callable(*args, **kwargs)
                 self.circuit_breaker.record_success()
                 return result
 

--- a/failsafe/fallback_failsafe.py
+++ b/failsafe/fallback_failsafe.py
@@ -57,7 +57,7 @@ class FallbackFailsafe:
         recent_exception = None
         for (fallback_option, failsafe) in self.failsafes:
             try:
-                return await failsafe.run(lambda: callable(fallback_option, *args, **kwargs))
+                return await failsafe.run(callable, fallback_option, *args, **kwargs)
             except FailsafeError as e:
                 recent_exception = e
                 logger.debug("Fallback option {} failed".format(fallback_option))

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -82,14 +82,14 @@ class TestFailsafe(unittest.TestCase):
         obtained = loop.run_until_complete(
             Failsafe().run(operation.task_with_arguments, 41, y=1)
         )
-        self.assertEqual(obtained, "{0}_42".format(Operation.__name__))
+        assert obtained == "{0}_42".format(Operation.__name__)
 
     def test_no_retry(self):
         succeeding_operation = create_succeeding_operation()
         loop.run_until_complete(
             Failsafe().run(succeeding_operation)
         )
-        self.assertEqual(succeeding_operation.called, 1)
+        assert succeeding_operation.called == 1
 
     def test_basic_retry(self):
         succeeding_operation = create_succeeding_operation()
@@ -97,7 +97,7 @@ class TestFailsafe(unittest.TestCase):
         loop.run_until_complete(
             Failsafe(retry_policy=policy).run(succeeding_operation)
         )
-        self.assertEqual(succeeding_operation.called, 1)
+        assert succeeding_operation.called == 1
 
     def test_retry_once(self):
         failing_operation = create_failing_operation()

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -41,6 +41,12 @@ def create_succeeding_operation():
     return operation
 
 
+class Operation:
+    async def task_with_arguments(self, x, y=0):
+        result = x + y
+        return "{0}_{1}".format(self.__class__.__name__, result)
+
+
 def create_failing_operation(exception=None):
     async def operation():
         operation.called += 1
@@ -71,11 +77,19 @@ class SomeAbortableException(Exception):
 
 class TestFailsafe(unittest.TestCase):
 
+    def test_failsafe_on_method_with_arguments(self):
+        operation = Operation()
+        obtained = loop.run_until_complete(
+            Failsafe().run(operation.task_with_arguments, 41, y=1)
+        )
+        self.assertEqual(obtained, "{0}_42".format(Operation.__name__))
+
     def test_no_retry(self):
         succeeding_operation = create_succeeding_operation()
         loop.run_until_complete(
             Failsafe().run(succeeding_operation)
         )
+        self.assertEqual(succeeding_operation.called, 1)
 
     def test_basic_retry(self):
         succeeding_operation = create_succeeding_operation()
@@ -83,6 +97,7 @@ class TestFailsafe(unittest.TestCase):
         loop.run_until_complete(
             Failsafe(retry_policy=policy).run(succeeding_operation)
         )
+        self.assertEqual(succeeding_operation.called, 1)
 
     def test_retry_once(self):
         failing_operation = create_failing_operation()

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -41,12 +41,6 @@ def create_succeeding_operation():
     return operation
 
 
-class Operation:
-    async def task_with_arguments(self, x, y=0):
-        result = x + y
-        return "{0}_{1}".format(self.__class__.__name__, result)
-
-
 def create_failing_operation(exception=None):
     async def operation():
         operation.called += 1
@@ -78,6 +72,11 @@ class SomeAbortableException(Exception):
 class TestFailsafe(unittest.TestCase):
 
     def test_failsafe_on_method_with_arguments(self):
+        class Operation:
+            async def task_with_arguments(self, x, y=0):
+                result = x + y
+                return "{0}_{1}".format(self.__class__.__name__, result)
+
         operation = Operation()
         obtained = loop.run_until_complete(
             Failsafe().run(operation.task_with_arguments, 41, y=1)


### PR DESCRIPTION
Extend ``Failsafe.run()`` to accept the arguments from the callers.

Updated tests and documentation.

Also updated the version of ``aiohttp`` used in the tests, to make it compatible with Python 3.7+.

Fixes https://github.com/Skyscanner/pyfailsafe/issues/35